### PR TITLE
Remove BUMP MPI calls

### DIFF
--- a/src/fckit/module/fckit_mpi.cc
+++ b/src/fckit/module/fckit_mpi.cc
@@ -162,9 +162,7 @@ int32 fckit__mpi__minloc() {
     return int( eckit::mpi::minloc() );
 }
 int32 fckit__mpi__info_null() {
-//  With an updated ECKIT version, should be:
-//  return int( eckit::mpi::info_null() );
-    return int( 0 );
+    return int( eckit::mpi::info_null() );
 }
 
 void fckit__mpi__allreduce_int32( const Comm* comm, const int32* in, int32* out, size_t count, int32 operation ) {

--- a/src/fckit/module/fckit_mpi.cc
+++ b/src/fckit/module/fckit_mpi.cc
@@ -161,9 +161,6 @@ int32 fckit__mpi__maxloc() {
 int32 fckit__mpi__minloc() {
     return int( eckit::mpi::minloc() );
 }
-int32 fckit__mpi__info_null() {
-    return eckit::mpi::info_null();
-}
 
 void fckit__mpi__allreduce_int32( const Comm* comm, const int32* in, int32* out, size_t count, int32 operation ) {
     if ( comm )
@@ -383,6 +380,13 @@ int fckit__mpi__anysource( const Comm* comm ) {
         return comm->anySource();
     else
         return eckit::mpi::comm().anySource();
+}
+
+int fckit__mpi__info_null( const Comm* comm ) {
+    if ( comm )
+        return comm->infoNull();
+    else
+        return eckit::mpi::comm().infoNull();
 }
 
 void fckit__mpi__send_int32( const Comm* comm, int32* buffer, size_t count, int32 dest, int32 tag ) {

--- a/src/fckit/module/fckit_mpi.cc
+++ b/src/fckit/module/fckit_mpi.cc
@@ -162,7 +162,9 @@ int32 fckit__mpi__minloc() {
     return int( eckit::mpi::minloc() );
 }
 int32 fckit__mpi__info_null() {
-    return int( eckit::mpi::info_null() );
+//  With an updated ECKIT version, should be:
+//  return int( eckit::mpi::info_null() );
+    return int( 0 );
 }
 
 void fckit__mpi__allreduce_int32( const Comm* comm, const int32* in, int32* out, size_t count, int32 operation ) {

--- a/src/fckit/module/fckit_mpi.cc
+++ b/src/fckit/module/fckit_mpi.cc
@@ -161,6 +161,9 @@ int32 fckit__mpi__maxloc() {
 int32 fckit__mpi__minloc() {
     return int( eckit::mpi::minloc() );
 }
+int32 fckit__mpi__info_null() {
+    return int( eckit::mpi::info_null() );
+}
 
 void fckit__mpi__allreduce_int32( const Comm* comm, const int32* in, int32* out, size_t count, int32 operation ) {
     if ( comm )

--- a/src/fckit/module/fckit_mpi.cc
+++ b/src/fckit/module/fckit_mpi.cc
@@ -162,7 +162,7 @@ int32 fckit__mpi__minloc() {
     return int( eckit::mpi::minloc() );
 }
 int32 fckit__mpi__info_null() {
-    return int( eckit::mpi::info_null() );
+    return eckit::mpi::info_null();
 }
 
 void fckit__mpi__allreduce_int32( const Comm* comm, const int32* in, int32* out, size_t count, int32 operation ) {

--- a/src/fckit/module/fckit_mpi.fypp
+++ b/src/fckit/module/fckit_mpi.fypp
@@ -251,7 +251,7 @@ contains
     !! Minloc operator that can be passed to collective method
   procedure, public, nopass :: maxloc         => fckit_mpi_maxloc
     !! Maxloc operator that can be passed to collective method
-  procedure, public, nopass :: info_null  => fckit_mpi_info_null
+  procedure, public, nopass :: info_null      => fckit_mpi_info_null
     !! MPI info null value that can be passed for I/O methods
 endtype
 

--- a/src/fckit/module/fckit_mpi.fypp
+++ b/src/fckit/module/fckit_mpi.fypp
@@ -108,6 +108,7 @@ public :: fckit_mpi_min
 public :: fckit_mpi_max
 public :: fckit_mpi_minloc
 public :: fckit_mpi_maxloc
+public :: fckit_mpi_info_null
 
 !========================================================================
 
@@ -250,7 +251,8 @@ contains
     !! Minloc operator that can be passed to collective method
   procedure, public, nopass :: maxloc         => fckit_mpi_maxloc
     !! Maxloc operator that can be passed to collective method
-
+  procedure, public, nopass :: info_null  => fckit_mpi_info_null
+    !! MPI info null value that can be passed for I/O methods
 endtype
 
 type(fckit_mpi_comm) :: fckit_mpi
@@ -387,6 +389,11 @@ interface
   function fckit__mpi__maxloc() bind(c)
     use, intrinsic :: iso_c_binding, only : c_int32_t
     integer(c_int32_t) :: fckit__mpi__maxloc
+  end function
+
+  function fckit__mpi__info_null() bind(c)
+    use, intrinsic :: iso_c_binding, only : c_int32_t
+    integer(c_int32_t) :: fckit__mpi__info_null
   end function
 
 #:for dtype,ftype,btype in types
@@ -554,6 +561,12 @@ function fckit_mpi_maxloc() result(code)
   use, intrinsic :: iso_c_binding, only : c_int32_t
   integer(c_int32_t) :: code
   code = fckit__mpi__maxloc()
+end function
+
+function fckit_mpi_info_null() result(code)
+  use, intrinsic :: iso_c_binding, only : c_int32_t
+  integer(c_int32_t) :: code
+  code = fckit__mpi__info_null()
 end function
 
 !---------------------------------------------------------------------------------------

--- a/src/fckit/module/fckit_mpi.fypp
+++ b/src/fckit/module/fckit_mpi.fypp
@@ -108,7 +108,6 @@ public :: fckit_mpi_min
 public :: fckit_mpi_max
 public :: fckit_mpi_minloc
 public :: fckit_mpi_maxloc
-public :: fckit_mpi_info_null
 
 !========================================================================
 
@@ -190,6 +189,9 @@ contains
   procedure, public :: anysource
     !! anysource
 
+  procedure, public :: info_null
+    !! info_null
+
   @:begin_interface( allreduce )
   @:generate_interfaces( allreduce )
   @:generate_interfaces( allreduce_inplace )
@@ -251,8 +253,6 @@ contains
     !! Minloc operator that can be passed to collective method
   procedure, public, nopass :: maxloc         => fckit_mpi_maxloc
     !! Maxloc operator that can be passed to collective method
-  procedure, public, nopass :: info_null      => fckit_mpi_info_null
-    !! MPI info null value that can be passed for I/O methods
 endtype
 
 type(fckit_mpi_comm) :: fckit_mpi
@@ -391,11 +391,6 @@ interface
     integer(c_int32_t) :: fckit__mpi__maxloc
   end function
 
-  function fckit__mpi__info_null() bind(c)
-    use, intrinsic :: iso_c_binding, only : c_int32_t
-    integer(c_int32_t) :: fckit__mpi__info_null
-  end function
-
 #:for dtype,ftype,btype in types
   subroutine fckit__mpi__allreduce_${dtype}$(comm,in,out,count,operation) bind(c)
     use, intrinsic :: iso_c_binding
@@ -521,6 +516,11 @@ interface
     integer(c_int32_t), dimension(*) :: status
   end subroutine
 
+  function fckit__mpi__info_null(comm) bind(c)
+    use, intrinsic :: iso_c_binding, only : c_int32_t, c_ptr
+    integer(c_int32_t) fckit__mpi__info_null
+    type(c_ptr), value :: comm
+  end function
 end interface
 
 !========================================================================
@@ -561,12 +561,6 @@ function fckit_mpi_maxloc() result(code)
   use, intrinsic :: iso_c_binding, only : c_int32_t
   integer(c_int32_t) :: code
   code = fckit__mpi__maxloc()
-end function
-
-function fckit_mpi_info_null() result(code)
-  use, intrinsic :: iso_c_binding, only : c_int32_t
-  integer(c_int32_t) :: code
-  code = fckit__mpi__info_null()
 end function
 
 !---------------------------------------------------------------------------------------
@@ -718,6 +712,15 @@ function anysource(this)
   integer(c_int32_t) :: anysource
   class(fckit_mpi_comm), intent(in) :: this
   anysource = fckit__mpi__anysource(this%CPTR_PGIBUG_A)
+end function
+
+!---------------------------------------------------------------------------------------
+
+function info_null(this)
+  use, intrinsic :: iso_c_binding, only : c_int32_t
+  integer(c_int32_t) :: info_null
+  class(fckit_mpi_comm), intent(in) :: this
+  info_null = fckit__mpi__info_null(this%CPTR_PGIBUG_A)
 end function
 
 !---------------------------------------------------------------------------------------


### PR DESCRIPTION
See https://github.com/JCSDA/saber/pull/28#issuecomment-535855089 for details.

I have reproduced what is done for the "fckit_mpi_maxloc" function.