### PR TITLE
Add directory label for CDash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@ set( ENABLE_LARGE_FILE_SUPPORT  OFF   CACHE BOOL " " )
 project( fckit C CXX Fortran )
 
 set( CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/../ecbuild/cmake")
+
+set( CMAKE_DIRECTORY_LABELS "fckit" )
+
 set( ECBUILD_DEFAULT_BUILD_TYPE Release )
 
 include( ecbuild_system NO_POLICY_SCOPE )


### PR DESCRIPTION
Adds in a single line to CMakeLists.txt allowing CDash dashboards to recognize fckit as a separate project within a bundle.

Basically, this allows us to separate fckit warnings and errors from the rest of the bundle.
