### PR TITLE
Add a constructor for fckit_mpi_comm

### DIFF
--- a/src/fckit/module/fckit_mpi.cc
+++ b/src/fckit/module/fckit_mpi.cc
@@ -49,7 +49,7 @@ const Comm* fckit__mpi__comm( const char* name ) {
 }
 
 const Comm* fckit__mpi__comm_ptr( const eckit::mpi::Comm* ptr_comm ) {
-    return &(*ptr_comm);
+    return ptr_comm;
 }
 
 const Comm* fckit__mpi__comm_wrap( int32 comm ) {

--- a/src/fckit/module/fckit_mpi.cc
+++ b/src/fckit/module/fckit_mpi.cc
@@ -48,10 +48,6 @@ const Comm* fckit__mpi__comm( const char* name ) {
     return &eckit::mpi::comm( name );
 }
 
-const Comm* fckit__mpi__comm_ptr( const eckit::mpi::Comm* ptr_comm ) {
-    return ptr_comm;
-}
-
 const Comm* fckit__mpi__comm_wrap( int32 comm ) {
     std::ostringstream s;
     s << "fort." << comm;

--- a/src/fckit/module/fckit_mpi.cc
+++ b/src/fckit/module/fckit_mpi.cc
@@ -48,6 +48,10 @@ const Comm* fckit__mpi__comm( const char* name ) {
     return &eckit::mpi::comm( name );
 }
 
+const Comm* fckit__mpi__comm_ptr( const eckit::mpi::Comm* ptr_comm ) {
+    return &(*ptr_comm);
+}
+
 const Comm* fckit__mpi__comm_wrap( int32 comm ) {
     std::ostringstream s;
     s << "fort." << comm;

--- a/src/fckit/module/fckit_mpi.fypp
+++ b/src/fckit/module/fckit_mpi.fypp
@@ -294,6 +294,13 @@ interface
     character(kind=c_char), dimension(*) :: name
   end function
 
+  ! const fckit::mpi::Comm* fckit__mpi__comm_ptr(const eckit::mpi::Comm* comm)
+  function fckit__mpi__comm_ptr(comm) bind(c)
+    use, intrinsic :: iso_c_binding, only: c_ptr
+    type(c_ptr) :: fckit__mpi__comm_ptr
+    type(c_ptr), value :: comm
+  end function
+
   ! const fckit::mpi::Comm* fckit__mpi__comm_wrap(int comm)
   function fckit__mpi__comm_wrap(comm) bind(c)
     use, intrinsic :: iso_c_binding, only: c_ptr, c_int32_t
@@ -757,7 +764,7 @@ subroutine allgather_${dtype}$_r0(this,in,out)
   ${ftype}$, intent(inout) :: out(:)
   ${btype}$, pointer :: view_in(:)
   ${btype}$, pointer :: view_out(:)
-  ${btype}$ :: mold 
+  ${btype}$ :: mold
   view_in => array_view1d(in,mold)
   view_out => array_view1d(out,mold)
   call fckit__mpi__allgather_${dtype}$(this%c_ptr(),view_in(1),view_out)
@@ -949,7 +956,7 @@ subroutine allreduce_${dtype}$_r${rank}$(this,in,out,operation)
 
   use, intrinsic :: iso_c_binding
   use fckit_array_module, only: array_view1d
-  
+
   class(fckit_mpi_comm), intent(in) :: this
     !! This communicator
   ${ftype}$, intent(in)    :: in${dim[rank]}$
@@ -974,7 +981,7 @@ subroutine allreduce_inplace_${dtype}$_r${rank}$(this,inout,operation)
 
   use, intrinsic :: iso_c_binding
   use fckit_array_module, only: array_view1d
-  
+
   class(fckit_mpi_comm), intent(in) :: this
     !! This communicator
   ${ftype}$, intent(inout) :: inout${dim[rank]}$
@@ -1005,7 +1012,7 @@ subroutine broadcast_${dtype}$_r${rank}$(this,buffer,root)
     !! MPI rank to broadcast from
 
   ${btype}$, pointer :: view_buffer(:)
-  ${btype}$ :: mold 
+  ${btype}$ :: mold
   view_buffer  => array_view1d(buffer,mold)
   call fckit__mpi__broadcast_${dtype}$(this%CPTR_PGIBUG_A,view_buffer, &
     int(ubound(view_buffer,1),c_size_t),int(root,c_size_t))
@@ -1042,7 +1049,7 @@ subroutine receive_${dtype}$_r${rank}$(this,buffer,source,tag,status)
 
   use, intrinsic :: iso_c_binding
   use fckit_array_module, only: array_view1d
-  
+
   class(fckit_mpi_comm), intent(in) :: this
     !! This communicator
   ${ftype}$, intent(inout) :: buffer${dim[rank]}$
@@ -1077,7 +1084,7 @@ function isend_${dtype}$_r${rank}$(this,buffer,dest,tag) result(request)
 
   use, intrinsic :: iso_c_binding
   use fckit_array_module, only: array_view1d
-  
+
   integer(c_int32_t) :: request
     !! Returned MPI request
   class(fckit_mpi_comm), intent(in) :: this

--- a/src/fckit/module/fckit_mpi.fypp
+++ b/src/fckit/module/fckit_mpi.fypp
@@ -259,6 +259,7 @@ type(fckit_mpi_comm) :: fckit_mpi
 
 interface fckit_mpi_comm
   module procedure comm_constructor
+  module procedure comm_constructor_ptr
   module procedure comm_wrap
 end interface
 
@@ -294,11 +295,11 @@ interface
     character(kind=c_char), dimension(*) :: name
   end function
 
-  ! const fckit::mpi::Comm* fckit__mpi__comm_ptr(const eckit::mpi::Comm* comm)
-  function fckit__mpi__comm_ptr(comm) bind(c)
+  ! const fckit::mpi::Comm* fckit__mpi__comm_ptr(c_comm)
+  function fckit__mpi__comm_ptr(c_comm) bind(c)
     use, intrinsic :: iso_c_binding, only: c_ptr
     type(c_ptr) :: fckit__mpi__comm_ptr
-    type(c_ptr), value :: comm
+    type(c_ptr) :: c_comm
   end function
 
   ! const fckit::mpi::Comm* fckit__mpi__comm_wrap(int comm)
@@ -622,6 +623,13 @@ function comm_constructor(name) result(this)
   else
     call this%reset_c_ptr( fckit__mpi__comm_default() )
   endif
+end function
+
+function comm_constructor_ptr(comm) result(this)
+  use, intrinsic :: iso_c_binding, only: c_ptr
+  type(fckit_mpi_comm) :: this
+  type(c_ptr), intent(in) :: comm
+  call this%reset_c_ptr( fckit__mpi__comm_ptr(comm) )
 end function
 
 function comm_wrap(comm) result(this)

--- a/src/fckit/module/fckit_mpi.fypp
+++ b/src/fckit/module/fckit_mpi.fypp
@@ -621,7 +621,7 @@ end function
 function comm_constructor_ptr(comm) result(this)
   use, intrinsic :: iso_c_binding, only: c_ptr
   type(fckit_mpi_comm) :: this
-  type(c_ptr), value, intent(in) :: comm
+  type(c_ptr), intent(in) :: comm
   call this%reset_c_ptr( comm )
 end function
 

--- a/src/fckit/module/fckit_mpi.fypp
+++ b/src/fckit/module/fckit_mpi.fypp
@@ -295,13 +295,6 @@ interface
     character(kind=c_char), dimension(*) :: name
   end function
 
-  ! const fckit::mpi::Comm* fckit__mpi__comm_ptr(c_comm)
-  function fckit__mpi__comm_ptr(c_comm) bind(c)
-    use, intrinsic :: iso_c_binding, only: c_ptr
-    type(c_ptr) :: fckit__mpi__comm_ptr
-    type(c_ptr) :: c_comm
-  end function
-
   ! const fckit::mpi::Comm* fckit__mpi__comm_wrap(int comm)
   function fckit__mpi__comm_wrap(comm) bind(c)
     use, intrinsic :: iso_c_binding, only: c_ptr, c_int32_t
@@ -628,8 +621,8 @@ end function
 function comm_constructor_ptr(comm) result(this)
   use, intrinsic :: iso_c_binding, only: c_ptr
   type(fckit_mpi_comm) :: this
-  type(c_ptr), intent(in) :: comm
-  call this%reset_c_ptr( fckit__mpi__comm_ptr(comm) )
+  type(c_ptr), value, intent(in) :: comm
+  call this%reset_c_ptr( comm )
 end function
 
 function comm_wrap(comm) result(this)

--- a/src/fckit/module/fckit_mpi.fypp
+++ b/src/fckit/module/fckit_mpi.fypp
@@ -259,7 +259,7 @@ type(fckit_mpi_comm) :: fckit_mpi
 
 interface fckit_mpi_comm
   module procedure comm_constructor
-  module procedure comm_constructor_ptr
+  module procedure comm_wrap_ptr
   module procedure comm_wrap
 end interface
 
@@ -618,7 +618,7 @@ function comm_constructor(name) result(this)
   endif
 end function
 
-function comm_constructor_ptr(comm) result(this)
+function comm_wrap_ptr(comm) result(this)
   use, intrinsic :: iso_c_binding, only: c_ptr
   type(fckit_mpi_comm) :: this
   type(c_ptr), intent(in) :: comm


### PR DESCRIPTION
This constructor takes a pointer to an eckit::mpi::Comm and passes it to Fortran. No need to pass the name and length of the name of the constructor anymore, I will do the changes in other branches. This will make the interface c++ / fortran easier for passing communicators.