### PR TITLE
Fix JSON.h location in eckit

### DIFF
--- a/src/fckit/module/fckit_configuration.cc
+++ b/src/fckit/module/fckit_configuration.cc
@@ -20,7 +20,7 @@
 #include "eckit/config/YAMLConfiguration.h"
 #include "eckit/exception/Exceptions.h"
 #include "eckit/filesystem/PathName.h"
-#include "eckit/parser/JSON.h"
+#include "eckit/log/JSON.h"
 #include "eckit/parser/JSONParser.h"
 
 using eckit::CodeLocation;


### PR DESCRIPTION
Fix JSON.h header location from eckit.  Eckit-1.4.0 is warning about this.