### PR TITLE
Remove pre-processor warnings.  

### DIFF
--- a/src/tests/test_broadcast_file.F90
+++ b/src/tests/test_broadcast_file.F90
@@ -17,7 +17,7 @@
 
 #if COMPILER_BUGS
 #define NO_COMPILER_BUGS 0
-#warning Some tests disabled due to gfortran 7 compiler bug. Only one TEST at a time may be compiled.
+! #warning Some tests disabled due to gfortran 7 compiler bug. Only one TEST at a time may be compiled.
 #else
 #define NO_COMPILER_BUGS 1
 #endif

--- a/src/tests/test_configuration.F90
+++ b/src/tests/test_configuration.F90
@@ -22,7 +22,7 @@
 
 #if COMPILER_BUGS
 #define NO_COMPILER_BUGS 0
-#warning Some tests disabled due to gfortran 7 and 8 compiler bug. Only one TEST at a time may be compiled.
+! #warning Some tests disabled due to gfortran 7 and 8 compiler bug. Only one TEST at a time may be compiled.
 #else
 #define NO_COMPILER_BUGS 1
 #endif

--- a/src/tests/test_shared_ptr.F90
+++ b/src/tests/test_shared_ptr.F90
@@ -590,7 +590,7 @@ TEST( test_shared_object_allocatable_list_auto_manual )
   write(0,'(A)')
 #else
 #ifndef __ibmxl__
-#warning test_shared_object_allocatable_list_auto_manual disabled
+! #warning test_shared_object_allocatable_list_auto_manual disabled
 #endif
 #endif
 END_TEST
@@ -611,7 +611,7 @@ TEST( test_shared_object_allocatable_list_manual_auto )
   write(0,'(A)')
 #else
 #ifndef __ibmxl__
-#warning test_shared_object_allocatable_list_manual_auto disabled
+! #warning test_shared_object_allocatable_list_manual_auto disabled
 #endif
 #endif
 END_TEST
@@ -632,7 +632,7 @@ TEST( test_shared_object_allocatable_list_manual_manual )
   write(0,'(A)')
 #else
 #ifndef __ibmxl__
-#warning test_shared_object_allocatable_list_manual_manual disabled
+! #warning test_shared_object_allocatable_list_manual_manual disabled
 #endif
 #endif
 END_TEST


### PR DESCRIPTION
No reason to warn if the tests are skipped.  The tests are the problem not the compiler.