### PR TITLE
Remove developer-only warnings from release builds

### DIFF
--- a/cmake/add_fctest.cmake
+++ b/cmake/add_fctest.cmake
@@ -100,6 +100,10 @@ cmake_policy( SET CMP0064 NEW ) # Recognize ``TEST`` as operator for the ``if()`
               set_source_files_properties( ${TESTRUNNER} PROPERTIES ${_prop} ${TESTSUITE_PROPERTY} )
           endif()
       endforeach()
+      if(${CMAKE_Fortran_COMPILER_ID} MATCHES GNU)
+          #Disable developer-only pre-processor warnings when not compiling for Debug configurations
+          target_compile_options(${_PAR_TARGET} PRIVATE $<$<NOT:$<CONFIG:Debug>>:-Wno-cpp>)
+      endif()
 
       add_custom_target( ${_PAR_TARGET}_testsuite SOURCES ${TESTSUITE} )
   endif()

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -34,7 +34,6 @@ add_fctest( TARGET  fckit_test_shared_ptr
             SOURCES
               test_shared_ptr.F90
               test_shared_ptr.cc
-            FFLAGS $<$<NOT:$<CONFIG:Debug>>:-Wno-cpp>
             LIBS    fckit)
 
 add_fctest( TARGET  fckit_test_mpi
@@ -58,7 +57,6 @@ add_fctest( TARGET  fckit_test_configuration
             SOURCES test_configuration.F90
             DEFINITIONS ${FCKIT_DEFINITIONS}
             CONDITION HAVE_ECKIT
-            FFLAGS $<$<NOT:$<CONFIG:Debug>>:-Wno-cpp>
             LIBS    fckit)
 
 add_fctest( TARGET  fckit_test_broadcast_file
@@ -67,7 +65,6 @@ add_fctest( TARGET  fckit_test_broadcast_file
             MPI 4
             DEFINITIONS ${FCKIT_DEFINITIONS}
             CONDITION HAVE_ECKIT AND ECKIT_HAVE_MPI
-            FFLAGS $<$<NOT:$<CONFIG:Debug>>:-Wno-cpp>
             LIBS    fckit)
 
 endif()

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_fctest( TARGET  fckit_test_shared_ptr
             SOURCES
               test_shared_ptr.F90
               test_shared_ptr.cc
+            FFLAGS $<$<NOT:$<CONFIG:Debug>>:-Wno-cpp>
             LIBS    fckit)
 
 add_fctest( TARGET  fckit_test_mpi
@@ -57,6 +58,7 @@ add_fctest( TARGET  fckit_test_configuration
             SOURCES test_configuration.F90
             DEFINITIONS ${FCKIT_DEFINITIONS}
             CONDITION HAVE_ECKIT
+            FFLAGS $<$<NOT:$<CONFIG:Debug>>:-Wno-cpp>
             LIBS    fckit)
 
 add_fctest( TARGET  fckit_test_broadcast_file
@@ -65,6 +67,7 @@ add_fctest( TARGET  fckit_test_broadcast_file
             MPI 4
             DEFINITIONS ${FCKIT_DEFINITIONS}
             CONDITION HAVE_ECKIT AND ECKIT_HAVE_MPI
+            FFLAGS $<$<NOT:$<CONFIG:Debug>>:-Wno-cpp>
             LIBS    fckit)
 
 endif()


### PR DESCRIPTION
Using gfortran, some Fckit tests generate compile-time warnings that are intended for fckit developers.  This fix keeps the warnings on for Debug builds, but eliminates them for Release builds using gfortran.   This is hopefully the least intrusive and easiest maintain solution to eliminating the compile-time warnings.