### PR TITLE
Set string array in configuration

### DIFF
--- a/src/fckit/module/fckit_configuration.F90
+++ b/src/fckit/module/fckit_configuration.F90
@@ -506,20 +506,25 @@ subroutine set_string(this, name, value)
   call c_fckit_configuration_set_string(this%CPTR_PGIBUG_B, c_str(name) , c_str(value) )
 end subroutine
 
-subroutine set_array_string(this, name, length, value)
+subroutine set_array_string(this, name, value)
   use, intrinsic :: iso_c_binding, only : c_f_pointer
   use fckit_c_interop_module, only : c_str, c_ptr_to_string, c_ptr_free
   class(fckit_Configuration), intent(in) :: this
   character(kind=c_char,len=*), intent(in) :: name
-  integer(c_size_t), intent(in) :: length
-  character(kind=c_char,len=length), intent(in) :: value(:)
-  character(kind=c_char,len=length*size(value)) :: flatvalue
+  character(kind=c_char,len=*), intent(in) :: value(:)
+  character(kind=c_char,len=:), allocatable :: flatvalue
+  integer(c_size_t) :: length
   integer(c_int32_t) :: ii
-  do ii = 1, size(value)
-    flatvalue((ii-1)*length+1:ii*length) = value(ii)
-  enddo
-  call c_fckit_configuration_set_array_string(this%CPTR_PGIBUG_B, c_str(name), &
-    c_str(flatvalue), length, size(value,kind=c_size_t) )
+  length = 0
+  if( size(value) > 0 ) then
+    length = len(value(1))
+    allocate( character(len=length*size(value) ) :: flatvalue )
+    do ii = 1, size(value)
+      flatvalue((ii-1)*length+1:ii*length) = value(ii)
+    enddo
+    call c_fckit_configuration_set_array_string(this%CPTR_PGIBUG_B, c_str(name), &
+      &  c_str(flatvalue), length, size(value,kind=c_size_t) )
+  endif
 end subroutine
 
 subroutine set_array_int32(this, name, value)

--- a/src/fckit/module/fckit_configuration.F90
+++ b/src/fckit/module/fckit_configuration.F90
@@ -94,6 +94,7 @@ contains
   procedure, private :: set_real32
   procedure, private :: set_real64
   procedure, private :: set_string
+  procedure, private :: set_array_string
   procedure, private :: set_array_int32
   procedure, private :: set_array_int64
   procedure, private :: set_array_real32
@@ -135,6 +136,7 @@ contains
     set_real32, &
     set_real64, &
     set_string, &
+    set_array_string, &
     set_array_int32, &
     set_array_int64, &
     set_array_real32, &
@@ -502,6 +504,22 @@ subroutine set_string(this, name, value)
   character(kind=c_char,len=*), intent(in) :: name
   character(kind=c_char,len=*), intent(in) :: value
   call c_fckit_configuration_set_string(this%CPTR_PGIBUG_B, c_str(name) , c_str(value) )
+end subroutine
+
+subroutine set_array_string(this, name, length, value)
+  use, intrinsic :: iso_c_binding, only : c_f_pointer
+  use fckit_c_interop_module, only : c_str, c_ptr_to_string, c_ptr_free
+  class(fckit_Configuration), intent(in) :: this
+  character(kind=c_char,len=*), intent(in) :: name
+  integer(c_size_t), intent(in) :: length
+  character(kind=c_char,len=length), intent(in) :: value(:)
+  character(kind=c_char,len=length*size(value)) :: flatvalue
+  integer(c_int32_t) :: ii
+  do ii = 1, size(value)
+    flatvalue((ii-1)*length+1:ii*length) = value(ii)
+  enddo
+  call c_fckit_configuration_set_array_string(this%CPTR_PGIBUG_B, c_str(name), &
+    c_str(flatvalue), length, size(value,kind=c_size_t) )
 end subroutine
 
 subroutine set_array_int32(this, name, value)

--- a/src/fckit/module/fckit_configuration.cc
+++ b/src/fckit/module/fckit_configuration.cc
@@ -153,6 +153,20 @@ void c_fckit_configuration_set_string( Configuration* This, const char* name, co
         throw NotLocalConfiguration( Here() );
 }
 
+void c_fckit_configuration_set_array_string( Configuration* This, const char* name, const char* value, size_t length, size_t size ) {
+    ASSERT( This != nullptr );
+    vector<string> v;
+    for (size_t jj = 0; jj < size; ++jj ) {
+      char str[length];
+      strncpy( str, value + jj*length, length );
+      v.push_back( string( str ) );
+    }
+    if ( LocalConfiguration* local = dynamic_cast<LocalConfiguration*>( This ) )
+        local->set( string( name ), v );
+    else
+        throw NotLocalConfiguration( Here() );
+}
+
 void c_fckit_configuration_set_array_int32( Configuration* This, const char* name, int32 value[], size_t size ) {
     ASSERT( This != nullptr );
     vector<int32> v;

--- a/src/fckit/module/fckit_configuration.inc
+++ b/src/fckit/module/fckit_configuration.inc
@@ -177,6 +177,21 @@ end subroutine
 !-------------------------------------------------------------------------------
 
 !-------------------------------------------------------------------------------
+! void c_fckit_configuration_set_array_string (Configuration* This, const char* n
+!   ame, const char* value[], size_t size)
+!-------------------------------------------------------------------------------
+subroutine c_fckit_configuration_set_array_string( This, name, value, length, size ) bin&
+  &d(C,name="c_fckit_configuration_set_array_string")
+    use iso_c_binding, only: c_int32_t, c_size_t, c_ptr, c_char
+    type(c_ptr), value :: This
+    character(c_char), dimension(*) :: name
+    character(c_char), dimension(*) :: value
+    integer(c_size_t), value :: length
+    integer(c_size_t), value :: size
+end subroutine
+!-------------------------------------------------------------------------------
+
+!-------------------------------------------------------------------------------
 ! void c_fckit_configuration_set_array_int32 (Configuration* This, const char* n
 !   ame, int32 value[], size_t size)
 !-------------------------------------------------------------------------------

--- a/src/fckit/module/fckit_configuration.inc
+++ b/src/fckit/module/fckit_configuration.inc
@@ -178,7 +178,7 @@ end subroutine
 
 !-------------------------------------------------------------------------------
 ! void c_fckit_configuration_set_array_string (Configuration* This, const char* n
-!   ame, const char* value[], size_t size)
+!   ame, const char* value, size_t size)
 !-------------------------------------------------------------------------------
 subroutine c_fckit_configuration_set_array_string( This, name, value, length, size ) bin&
   &d(C,name="c_fckit_configuration_set_array_string")

--- a/src/tests/test_configuration.F90
+++ b/src/tests/test_configuration.F90
@@ -51,12 +51,16 @@ TEST( test_configuration )
 #if 1
   use fckit_configuration_module
   use fckit_log_module
+  use, intrinsic :: iso_c_binding, only : c_size_t
 
+  integer(c_size_t), parameter :: strlen = 10
   type(fckit_Configuration) :: config
   type(fckit_Configuration) :: nested
   type(fckit_Configuration) :: list(2)
   logical :: found
   logical :: logval
+  character(len=strlen), allocatable :: arrayset(:)
+  character(len=strlen), allocatable :: arrayget(:)
   integer :: intval
   integer :: j
 
@@ -82,6 +86,7 @@ TEST( test_configuration )
   !   p1: 1
   !   p2: 2
   !   logical : True
+  !   array_of_strings: string1, string2, string3
   ! }
 
   config = fckit_Configuration()
@@ -112,6 +117,12 @@ enddo
 #if ! FCKIT_HAVE_FINAL
   call nested%final()
 #endif
+
+  allocate( arrayset(3) )
+  arrayset(1) = "string1"
+  arrayset(2) = "string2"
+  arrayset(3) = "string3"
+  call config%set("array_of_strings",arrayset)
 
   ! --------------------- JSON ------------------
 
@@ -175,6 +186,12 @@ enddo
   write(0,*) "deallocate alist... done"
 
   call anested%final()
+
+  found = config%get("array_of_strings",strlen,arrayget)
+  FCTEST_CHECK( found )
+  FCTEST_CHECK_EQUAL( arrayget(1) , "string1" )
+  FCTEST_CHECK_EQUAL( arrayget(2) , "string2" )
+  FCTEST_CHECK_EQUAL( arrayget(3) , "string3" )
 
   ! There is a reported PGI/16.7 bug that makes this test segfault here.
   ! PGI/17.1 has this bug fixed.


### PR DESCRIPTION
Interfaces to set an array of strings in a config (credit: Marcin Chrust, ECMWF).